### PR TITLE
global: release mock v1.2.8

### DIFF
--- a/invenio_indexer/__init__.py
+++ b/invenio_indexer/__init__.py
@@ -180,6 +180,6 @@ If specific types of records have different rules (e.g. in case you had
 from .ext import InvenioIndexer
 from .proxies import current_record_to_index
 
-__version__ = "2.1.1"
+__version__ = "1.2.8" # Mock version due to invenio 3.4.1 pin
 
 __all__ = ("__version__", "InvenioIndexer", "current_record_to_index")


### PR DESCRIPTION
closes https://github.com/cernanalysispreservation/analysispreservation.cern.ch/issues/2784